### PR TITLE
fix: After install patch path

### DIFF
--- a/webshop/setup/install.py
+++ b/webshop/setup/install.py
@@ -233,7 +233,7 @@ def run_patches():
 
 	try:
 		for patch in patches:
-			frappe.get_attr(f"webshop.patches.after_install.{patch}.execute")()
+			frappe.get_attr(f"webshop.patches.{patch}.execute")()
 
 	finally:
 		frappe.flags.in_patch = False


### PR DESCRIPTION
Version: develop and Version-15

___

Actually, the patch will run after installing the webshop app. Here you define in `hook.py`
```
after_install = "webshop.setup.install.after_install" 
```

but the `install.py` file, the `run_patches()` method, the path is wrong.

https://github.com/frappe/webshop/blob/fe420333f68fa4b037fd8d6a72a73f546d6dff3c/webshop/setup/install.py#L236

because the `after_install` folder is not available in `patches`

so fix it in both branches.

Thank You!