### PR TITLE
fix(item): Show "Add to cart" if stock can't be checked

### DIFF
--- a/webshop/templates/generators/item/item_add_to_cart.html
+++ b/webshop/templates/generators/item/item_add_to_cart.html
@@ -91,7 +91,7 @@
 		<div class="mt-6 mb-5">
 			<div class="mb-4 d-flex">
 				<!-- Add to Cart -->
-				{% if product_info.price and (cart_settings.allow_items_not_in_stock or product_info.in_stock) %}
+				{% if product_info.price and (cart_settings.allow_items_not_in_stock or product_info.in_stock != false) %}
 					<a href="/cart" class="btn btn-light btn-view-in-cart hidden mr-2 font-md"
 						role="button">
 						{{  _("View in Cart") if cart_settings.enable_checkout else _("View in Quote") }}


### PR DESCRIPTION
In Webshop Settings, when `show_stock_availability` is not checked, then `item.in_stock` is neither `True` nor `False`, but instead undefined.

https://github.com/frappe/webshop/blob/2b6abdd9665a6f2123a24998065839f143bc8628/webshop/webshop/product_data_engine/query.py#L234-L235

Then, in the template on the web, if `allow_items_not_in_stock` is also not checked, and because `no such element: dict object['in_stock']` is falsy, the "Add to cart" button is hidden.

https://github.com/frappe/webshop/blob/2b6abdd9665a6f2123a24998065839f143bc8628/webshop/templates/generators/item/item_add_to_cart.html#L94
