### PR TITLE
Fix numeric attributes not returned. Issue #74

### DIFF
--- a/webshop/webshop/variant_selector/utils.py
+++ b/webshop/webshop/variant_selector/utils.py
@@ -100,7 +100,7 @@ def get_attributes_and_values(item_code):
 	"""
 	for attr_name in attribute_list:
 		if attr_name not in ordered_attribute_value_map:
-			numeric_list = sorted([i for i in valid_options[attr_name] if i.isnumeric()], key=int)
+			numeric_list = sorted([i for i in valid_options[attr_name] if i.replace(".","").isnumeric()], key=float)
 			ordered_attribute_value_map[attr_name] = numeric_list
 
 	# build attribute values in idx order

--- a/webshop/webshop/variant_selector/utils.py
+++ b/webshop/webshop/variant_selector/utils.py
@@ -93,6 +93,16 @@ def get_attributes_and_values(item_code):
 	for iv in item_attribute_values:
 		ordered_attribute_value_map.setdefault(iv.parent, []).append(iv.attribute_value)
 
+	"""Numeric attributes are not stored in the Item Attribute Value table.
+	However, they are included in valid_options. If they are not found in ordered_attribute_value_map
+	sort and add them to it. This does not include the entire range if there is no
+	product associated with specific number. Only possible values are returned.
+	"""
+	for attr_name in attribute_list:
+		if attr_name not in ordered_attribute_value_map:
+			numeric_list = sorted([i for i in valid_options[attr_name] if i.isnumeric()], key=int)
+			ordered_attribute_value_map[attr_name] = numeric_list
+
 	# build attribute values in idx order
 	for attr in attributes:
 		valid_attribute_values = valid_options.get(attr.attribute, [])


### PR DESCRIPTION
Numeric attributes are not stored in the _Item Attribute Value_ table so they are never returned by get_attributes_and_values(). For reference, they are stored in _Item Attribute_ table.

However, they are included in _item_variants_data_ which is then loaded into _valid_options_. If they are not found in _ordered_attribute_value_map_ sort and add them to it.

This **does not include the entire range** if there is no product associated with specific number. Only possible selectable values are returned so that the user doesn't waste time selecting a number that is not available.

For example, if the range is incremented by 1 for 1 to 100 but there are only variants for 1,20, and 37, the selectable options returned will be [1,20,37] instead of [1,2,3,...,99, 100] and making the user guess which item is available.