### PR TITLE
fix: Not able to rename the item

### DIFF
--- a/webshop/webshop/crud_events/item/invalidate_item_variants_cache.py
+++ b/webshop/webshop/crud_events/item/invalidate_item_variants_cache.py
@@ -4,7 +4,7 @@ from webshop.webshop.variant_selector.item_variants_cache import (
 )
 
 
-def execute(doc, *args):
+def execute(doc, method=None, old_name=None, new_name=None, merge=False):
     """
     Rebuild ItemVariantsCacheManager via Item or Website Item.
     """


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "apps/frappe/frappe/model/document.py", line 1658, in execute_action
    getattr(doc, __action)(**kwargs)
  File "apps/frappe/frappe/model/document.py", line 1040, in _rename
    self.name = rename_doc(doc=self, new=name, merge=merge, force=force, validate=validate_rename)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/rename_doc.py", line 206, in rename_doc
    new_doc.run_method("after_rename", old, new, merge)
  File "apps/frappe/frappe/model/document.py", line 960, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1320, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1304, in runner
    add_to_return_value(self, f(self, method, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: execute() takes from 1 to 2 positional arguments but 5 were given
```