### PR TITLE
fix: Webpages not working without login

### DIFF
--- a/webshop/patches.txt
+++ b/webshop/patches.txt
@@ -3,3 +3,4 @@
 [post_model_sync]
 
 webshop.patches.add_homepage_field
+webshop.patches.enable_allow_to_guest_view_for_item_group

--- a/webshop/patches/enable_allow_to_guest_view_for_item_group.py
+++ b/webshop/patches/enable_allow_to_guest_view_for_item_group.py
@@ -1,0 +1,8 @@
+import frappe
+from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+
+def execute():
+	frappe.reload_doc("setup", "doctype", "item_group")
+
+	make_property_setter("Item Group", "", "has_web_view", 1, "Check", for_doctype=True, validate_fields_for_doctype=False)
+	make_property_setter("Item Group", "", "allow_guest_to_view", 1, "Check", for_doctype=True, validate_fields_for_doctype=False)

--- a/webshop/templates/generators/item/item_add_to_cart.html
+++ b/webshop/templates/generators/item/item_add_to_cart.html
@@ -91,7 +91,7 @@
 		<div class="mt-6 mb-5">
 			<div class="mb-4 d-flex">
 				<!-- Add to Cart -->
-				{% if product_info.price and (cart_settings.allow_items_not_in_stock or product_info.in_stock != false) %}
+				{% if product_info.price and (cart_settings.allow_items_not_in_stock or product_info.get("in_stock")) %}
 					<a href="/cart" class="btn btn-light btn-view-in-cart hidden mr-2 font-md"
 						role="button">
 						{{  _("View in Cart") if cart_settings.enable_checkout else _("View in Quote") }}


### PR DESCRIPTION
After fixing of security issue (https://github.com/frappe/frappe/pull/24037), user was not able to see the Items listing on the portal without login and was the getting 404 error.

<img width="1336" alt="Screenshot 2024-02-22 at 4 23 28 PM" src="https://github.com/frappe/erpnext/assets/8780500/a75deb5c-2898-4208-b338-e91e19b2f9e6">


**After Fix**
Enabled "has_web_view" and "allow_guest_to_view" properties

<img width="1355" alt="Screenshot 2024-02-22 at 4 22 21 PM" src="https://github.com/frappe/erpnext/assets/8780500/c5381b46-a2fd-4e8a-bd98-c1db30313e03">




Fixed https://github.com/frappe/erpnext/pull/40881