### PR TITLE
Fix Jinja syntax error in item_add_to_cart.html

### DIFF
--- a/webshop/templates/generators/item/item_add_to_cart.html
+++ b/webshop/templates/generators/item/item_add_to_cart.html
@@ -91,11 +91,7 @@
 		<div class="mt-6 mb-5">
 			<div class="mb-4 d-flex">
 				<!-- Add to Cart -->
-<<<<<<< HEAD
-				{% if product_info.price and (cart_settings.allow_items_not_in_stock or product_info.in_stock) %}
-=======
 				{% if product_info.price and (cart_settings.allow_items_not_in_stock or product_info.get("in_stock")) %}
->>>>>>> 2f0f680a65 (fix: Webpages not working without login (#107))
 					<a href="/cart" class="btn btn-light btn-view-in-cart hidden mr-2 font-md"
 						role="button">
 						{{  _("View in Cart") if cart_settings.enable_checkout else _("View in Quote") }}


### PR DESCRIPTION
This PR resolves a Jinja syntax error in the item_add_to_cart.html template file that was causing an unexpected end of template error. The error occurred due to a misplaced Jinja block, resulting in an incomplete template.

### Changes Made:

Removed the erroneous Jinja code block causing the syntax error.
Updated the Jinja syntax to ensure correctness and proper closure of blocks.

### Testing:

Tested locally to verify that the Jinja syntax is correct and the unexpected end of template error is resolved.
Verified that the product page now loads correctly without encountering any errors.

### Screenshots:
#### Before
![image](https://github.com/frappe/webshop/assets/25708027/570ace79-0115-42f7-bb6e-742290091451)
#### After
![image](https://github.com/frappe/webshop/assets/25708027/101bcc9b-7738-46bd-8c5c-3fed25f3b07f)
