### PR TITLE
fix primary_action button URL in Item card group

### DIFF
--- a/webshop/webshop/web_template/item_card_group/item_card_group.html
+++ b/webshop/webshop/web_template/item_card_group/item_card_group.html
@@ -12,7 +12,7 @@
 		</div>
 		<div class="primary-action-section">
 			{%- if primary_action -%}
-			<a href="{{ action }}" class="btn btn-primary pull-right">
+			<a href="{{ primary_action }}" class="btn btn-primary pull-right">
 				{{ primary_action_label }}
 			</a>
 			{%- endif -%}


### PR DESCRIPTION
<img width="825" alt="Screenshot 2024-04-18 at 10 41 21 AM" src="https://github.com/frappe/webshop/assets/48287817/b7df030a-fb43-4244-98bf-0a38479c74c5">

changed {{ action }} to {{ primary_action }} to fix the URL