### PR TITLE
fix: translation in website item page

### DIFF
--- a/webshop/templates/generators/item/item_details.html
+++ b/webshop/templates/generators/item/item_details.html
@@ -7,7 +7,7 @@
 	<div class="d-flex">
 		<!-- title -->
 		<div class="product-title col-11" itemprop="name">
-			{{ doc.web_item_name }}
+			{{ _(doc.web_item_name) }}
 		</div>
 
 		<!-- Wishlist -->
@@ -34,7 +34,7 @@
 		<span class="product-item-code" itemprop="name">
 			{{ _("Item Code") }}:
 		</span>
-		<span itemprop="name">{{ doc.item_code }}</span>
+		<span itemprop="name">{{ _(doc.item_code) }}</span>
 	</p>
 	{% if has_variants %}
 		<!-- configure template -->
@@ -46,9 +46,9 @@
 	<!-- description -->
 	<div class="product-description" itemprop="description">
 	{% if frappe.utils.strip_html(doc.web_long_description or '') %}
-		{{ doc.web_long_description | safe }}
+		{{ _(doc.web_long_description) | safe }}
 	{% elif frappe.utils.strip_html(doc.description or '')  %}
-		{{ doc.description | safe }}
+		{{ _(doc.description) | safe }}
 	{% else %}
 		{{ "" }}
 	{% endif  %}

--- a/webshop/templates/generators/item/item_specifications.html
+++ b/webshop/templates/generators/item/item_specifications.html
@@ -4,14 +4,14 @@
 	<div class="col-md-11">
 		{% if not show_tabs %}
 			<div class="product-title mb-5 mt-4">
-				Product Details
+				{{ _("Product Details") }}
 			</div>
 		{% endif %}
 		<table class="table">
 		{% for d in website_specifications -%}
 			<tr>
-				<td class="spec-label">{{ d.label }}</td>
-				<td class="spec-content">{{ d.description }}</td>
+				<td class="spec-label">{{ _(d.label) }}</td>
+				<td class="spec-content">{{ _(d.description) }}</td>
 			</tr>
 		{%- endfor %}
 		</table>


### PR DESCRIPTION
fixes: https://discuss.frappe.io/t/translation-attributes-descriptions-web-item-name-etc/121794/3?u=ncp

**Before:**

<img width="1440" alt="image" src="https://github.com/frappe/webshop/assets/141945075/ed3d3ea0-5ea4-48a0-8a36-4ab3a7456495">


**After:**

<img width="1440" alt="image" src="https://github.com/frappe/webshop/assets/141945075/6e26a257-f8b8-4943-bfd0-8f5cdf5c6fa8">


And breadcrumbs defined is in the frappe app so it's not translated. but we will raise the PR as soon as possible.