### PR TITLE
fix: payment button appears even after the payment#16066

### DIFF
--- a/webshop/templates/pages/order.html
+++ b/webshop/templates/pages/order.html
@@ -37,10 +37,12 @@
 		<div class="form-column col-sm-6">
 			<div class="page-header-actions-block" data-html-block="header-actions">
 				<p>
+					{% if doc.doctype != "Sales Invoice" or doc.outstanding_amount > 0 %}
 					<a href="/api/method/erpnext.accounts.doctype.payment_request.payment_request.make_payment_request?dn={{ doc.name }}&dt={{ doc.doctype }}&submit_doc=1&order_type=Shopping Cart"
 						class="btn btn-primary btn-sm" id="pay-for-order">
 						{{ _("Pay") }} {{doc.get_formatted("grand_total") }}
 					</a>
+					{% endif %}
 				</p>
 			</div>
 		</div>


### PR DESCRIPTION
Even though the Payment is made successfully, it shows the Pay button as shown below:

<img width="1332" alt="Screenshot 2024-06-07 at 12 05 41 PM" src="https://github.com/frappe/webshop/assets/27720465/158efcbd-82d0-40fa-a65c-76481825de05">
