### PR TITLE
fix: product card not rendered in website builder#6864

### DIFF
--- a/webshop/templates/includes/macros.html
+++ b/webshop/templates/includes/macros.html
@@ -65,7 +65,7 @@
 
 {% endmacro %}
 
-{%- macro item_card(item, is_featured=False, is_full_width=False, align="Left") -%}
+{%- macro item_card(item, is_featured=False, is_full_width=False, align="Left",template="") -%}
 {%- set align_items_class = resolve_class({
 	'align-items-end': align == 'Right',
 	'align-items-center': align == 'Center',
@@ -86,12 +86,12 @@
 				<img class="card-img" src="{{ image }}" alt="{{ title }}">
 			</div>
 			<div class="col-md-6">
-				{{ item_card_body(title, description, item, is_featured, align) }}
+				{{ item_card_body(title, description, item, is_featured, align,template) }}
 			</div>
 		</div>
 		{% else %}
 			<div class="col-md-12">
-				{{ item_card_body(title, description, item, is_featured, align) }}
+				{{ item_card_body(title, description, item, is_featured, align,template) }}
 			</div>
 		{% endif %}
 	</div>
@@ -112,13 +112,13 @@
 			</div>
 		</a>
 		{% endif %}
-		{{ item_card_body(title, description, item, is_featured, align) }}
+		{{ item_card_body(title, description, item, is_featured, align,template) }}
 	</div>
 </div>
 {% endif %}
 {%- endmacro -%}
 
-{%- macro item_card_body(title, description, item, is_featured, align) -%}
+{%- macro item_card_body(title, description, item, is_featured, align,template) -%}
 {%- set align_class = resolve_class({
 	'text-right': align == 'Right',
 	'text-center': align == 'Center' and not is_featured,
@@ -137,7 +137,9 @@
 			{{ description or '' }}
 		</div>
 	{% else %}
+		{% if template != "Product Card" %}
 		<div class="product-category">{{ item.item_group or '' }}</div>
+		{% endif %}
 	{% endif %}
 </div>
 {%- endmacro -%}

--- a/webshop/templates/pages/order.html
+++ b/webshop/templates/pages/order.html
@@ -37,10 +37,12 @@
 		<div class="form-column col-sm-6">
 			<div class="page-header-actions-block" data-html-block="header-actions">
 				<p>
+					{% if doc.doctype != "Sales Invoice" or doc.outstanding_amount > 0 %}
 					<a href="/api/method/erpnext.accounts.doctype.payment_request.payment_request.make_payment_request?dn={{ doc.name }}&dt={{ doc.doctype }}&submit_doc=1&order_type=Shopping Cart"
 						class="btn btn-primary btn-sm" id="pay-for-order">
 						{{ _("Pay") }} {{doc.get_formatted("grand_total") }}
 					</a>
+					{% endif %}
 				</p>
 			</div>
 		</div>

--- a/webshop/webshop/web_template/product_card/product_card.html
+++ b/webshop/webshop/web_template/product_card/product_card.html
@@ -1,0 +1,10 @@
+{%- from "webshop/templates/includes/macros.html" import item_card -%}
+
+<div class="section-with-cards item-card-group-section">
+    <div class="container">
+        <div class="row">
+            {%- set item_doc = frappe.get_doc("Website Item", values["item"]) -%}
+            {{ item_card(item=item_doc, is_featured=values["featured"], is_full_width=True, align="Center", template="Product Card") }}
+        </div>
+    </div>
+</div>

--- a/webshop/webshop/web_template/product_card/product_card.json
+++ b/webshop/webshop/web_template/product_card/product_card.json
@@ -8,7 +8,7 @@
    "fieldname": "item",
    "fieldtype": "Link",
    "label": "Item",
-   "options": "Item",
+   "options": "Website Item",
    "reqd": 0
   },
   {
@@ -20,7 +20,7 @@
   }
  ],
  "idx": 0,
- "modified": "2023-10-16 18:02:11.801746",
+ "modified": "2024-06-17 15:15:09.902754",
  "modified_by": "Administrator",
  "module": "Webshop",
  "name": "Product Card",


### PR DESCRIPTION
Product card was not displaying the in the website.
Now its displays on adding the Website Item in the Product Card Web Template in the Webpage.
<img width="297" alt="Screenshot 2024-06-19 at 11 10 58 AM" src="https://github.com/frappe/webshop/assets/27720465/f2288fb2-fa72-405c-abb1-376261508940">

When the featured check box is checked it shows like below:
<img width="586" alt="Screenshot 2024-06-19 at 11 10 27 AM" src="https://github.com/frappe/webshop/assets/27720465/f08ae265-6494-46ae-bdb4-169a1c7cefba">
