### PR TITLE
fix: extra space in the text field and country dropdown issue #18421

### DIFF
--- a/webshop/public/scss/webshop_cart.scss
+++ b/webshop/public/scss/webshop_cart.scss
@@ -721,8 +721,8 @@ body.product-page {
 				}
 
 				textarea {
-					width: 80%;
-					height: 60px;
+					width: 70%;
+					height: 30px;
 					font-size: 14px;
 				}
 
@@ -1378,4 +1378,26 @@ body.product-page {
 
 .mt-minus-1 {
 	margin-top: -1rem;
+}
+
+.tooltip-content {
+	position: absolute;
+	bottom: 100%;
+	left: 0;
+	z-index: 9999;
+	padding: 2px 6px;
+	border-radius: var(--border-radius-sm);
+	background-color: var(--bg-dark-gray);
+	color: var(--text-dark);
+	font-size: var(--text-xs);
+	opacity: 0;
+	cursor: copy;
+	transition: opacity 0.3s, transform 3s;
+	pointer-events: none;
+}
+
+.show-tooltip .frappe-control:hover .tooltip-content {
+	opacity: 1;
+	transform: translate3d(0, 0, 0);
+	pointer-events: auto;
 }

--- a/webshop/templates/includes/cart/cart_items.html
+++ b/webshop/templates/includes/cart/cart_items.html
@@ -49,11 +49,9 @@
 					</span>
 					{% endif %}
 
-					<div class="mt-2 notes">
-						<textarea data-item-code="{{d.item_code}}" class="form-control" rows="2" placeholder="{{ _('Add notes') }}">
-							{{d.additional_notes or ''}}
-						</textarea>
-					</div>
+						<div class="mt-2 notes">
+							<textarea data-item-code="{{d.item_code}}" class="form-control" rows="2" placeholder="{{ _('Add notes') }}">{{d.additional_notes or ''}}</textarea>
+						</div>
 				</div>
 			</div>
 		</td>

--- a/webshop/templates/includes/macros.html
+++ b/webshop/templates/includes/macros.html
@@ -65,7 +65,7 @@
 
 {% endmacro %}
 
-{%- macro item_card(item, is_featured=False, is_full_width=False, align="Left") -%}
+{%- macro item_card(item, is_featured=False, is_full_width=False, align="Left",template="") -%}
 {%- set align_items_class = resolve_class({
 	'align-items-end': align == 'Right',
 	'align-items-center': align == 'Center',
@@ -86,12 +86,12 @@
 				<img class="card-img" src="{{ image }}" alt="{{ title }}">
 			</div>
 			<div class="col-md-6">
-				{{ item_card_body(title, description, item, is_featured, align) }}
+				{{ item_card_body(title, description, item, is_featured, align,template) }}
 			</div>
 		</div>
 		{% else %}
 			<div class="col-md-12">
-				{{ item_card_body(title, description, item, is_featured, align) }}
+				{{ item_card_body(title, description, item, is_featured, align,template) }}
 			</div>
 		{% endif %}
 	</div>
@@ -112,13 +112,13 @@
 			</div>
 		</a>
 		{% endif %}
-		{{ item_card_body(title, description, item, is_featured, align) }}
+		{{ item_card_body(title, description, item, is_featured, align,template) }}
 	</div>
 </div>
 {% endif %}
 {%- endmacro -%}
 
-{%- macro item_card_body(title, description, item, is_featured, align) -%}
+{%- macro item_card_body(title, description, item, is_featured, align,template) -%}
 {%- set align_class = resolve_class({
 	'text-right': align == 'Right',
 	'text-center': align == 'Center' and not is_featured,
@@ -137,7 +137,9 @@
 			{{ description or '' }}
 		</div>
 	{% else %}
+		{% if template != "Product Card" %}
 		<div class="product-category">{{ item.item_group or '' }}</div>
+		{% endif %}
 	{% endif %}
 </div>
 {%- endmacro -%}

--- a/webshop/templates/pages/order.html
+++ b/webshop/templates/pages/order.html
@@ -37,10 +37,12 @@
 		<div class="form-column col-sm-6">
 			<div class="page-header-actions-block" data-html-block="header-actions">
 				<p>
+					{% if doc.doctype != "Sales Invoice" or doc.outstanding_amount > 0 %}
 					<a href="/api/method/erpnext.accounts.doctype.payment_request.payment_request.make_payment_request?dn={{ doc.name }}&dt={{ doc.doctype }}&submit_doc=1&order_type=Shopping Cart"
 						class="btn btn-primary btn-sm" id="pay-for-order">
 						{{ _("Pay") }} {{doc.get_formatted("grand_total") }}
 					</a>
+					{% endif %}
 				</p>
 			</div>
 		</div>

--- a/webshop/webshop/web_template/product_card/product_card.html
+++ b/webshop/webshop/web_template/product_card/product_card.html
@@ -1,0 +1,10 @@
+{%- from "webshop/templates/includes/macros.html" import item_card -%}
+
+<div class="section-with-cards item-card-group-section">
+    <div class="container">
+        <div class="row">
+            {%- set item_doc = frappe.get_doc("Website Item", values["item"]) -%}
+            {{ item_card(item=item_doc, is_featured=values["featured"], is_full_width=True, align="Center", template="Product Card") }}
+        </div>
+    </div>
+</div>

--- a/webshop/webshop/web_template/product_card/product_card.json
+++ b/webshop/webshop/web_template/product_card/product_card.json
@@ -8,7 +8,7 @@
    "fieldname": "item",
    "fieldtype": "Link",
    "label": "Item",
-   "options": "Item",
+   "options": "Website Item",
    "reqd": 0
   },
   {
@@ -20,7 +20,7 @@
   }
  ],
  "idx": 0,
- "modified": "2023-10-16 18:02:11.801746",
+ "modified": "2024-06-17 15:15:09.902754",
  "modified_by": "Administrator",
  "module": "Webshop",
  "name": "Product Card",


### PR DESCRIPTION
Part 1:
Extra Space in the Text field has been removed.
![image](https://github.com/user-attachments/assets/e09ea233-00af-41bf-8c52-68909343a21b)

Part 2:
Country dropdown was not appearing in the Address page.
![image](https://github.com/user-attachments/assets/c51a8815-579d-413a-b792-99e7e5b81fb6)

Par 3:
fieldname was appearing in the address page which was removed.
![image](https://github.com/user-attachments/assets/db98518d-12c9-4c6e-9893-d007f509c6d4)
