### PR TITLE
fix: clear cache for item group route

### DIFF
--- a/webshop/patches.txt
+++ b/webshop/patches.txt
@@ -4,3 +4,4 @@
 
 webshop.patches.add_homepage_field #09-05-2024
 webshop.patches.enable_allow_to_guest_view_for_item_group
+webshop.patches.clear_cache_for_item_group_route

--- a/webshop/patches/clear_cache_for_item_group_route.py
+++ b/webshop/patches/clear_cache_for_item_group_route.py
@@ -1,0 +1,7 @@
+import frappe
+from frappe.website.utils import clear_cache
+
+def execute():
+	for d in frappe.get_all("Item Group", filters={"show_in_website": 1}, pluck="route"):
+		if d.route:
+			clear_cache(d.route)


### PR DESCRIPTION
Issue: A few Item Group pages listing items are not found