### PR TITLE
fix: permission issue without login

### DIFF
--- a/webshop/hooks.py
+++ b/webshop/hooks.py
@@ -72,3 +72,8 @@ doc_events = {
         ],
     },
 }
+
+has_website_permission = {
+    "Website Item": "webshop.webshop.doctype.website_item.website_item.has_website_permission_for_website_item",
+    "Item Group": "webshop.webshop.doctype.website_item.website_item.has_website_permission_for_item_group"
+}

--- a/webshop/webshop/doctype/webshop_settings/webshop_settings.json
+++ b/webshop/webshop/doctype/webshop_settings/webshop_settings.json
@@ -15,6 +15,7 @@
   "hide_variants",
   "enable_variants",
   "show_price",
+  "login_required_to_view_products",
   "column_break_9",
   "show_stock_availability",
   "show_quantity_in_website",
@@ -366,12 +367,18 @@
    "fieldtype": "Check",
    "label": "Enable Redisearch",
    "read_only_depends_on": "eval:!doc.is_redisearch_loaded"
+  },
+  {
+   "default": "0",
+   "fieldname": "login_required_to_view_products",
+   "fieldtype": "Check",
+   "label": "Login Required to View Products"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-04-01 18:35:56.106756",
+ "modified": "2024-11-05 13:31:46.657592",
  "modified_by": "Administrator",
  "module": "Webshop",
  "name": "Webshop Settings",

--- a/webshop/webshop/doctype/website_item/website_item.json
+++ b/webshop/webshop/doctype/website_item/website_item.json
@@ -1,6 +1,5 @@
 {
  "actions": [],
- "allow_guest_to_view": 1,
  "allow_import": 1,
  "autoname": "naming_series",
  "creation": "2021-02-09 21:06:14.441698",
@@ -348,7 +347,7 @@
  "index_web_pages_for_search": 1,
  "links": [],
  "make_attachments_public": 1,
- "modified": "2022-09-30 04:01:52.090732",
+ "modified": "2024-11-05 13:41:45.347700",
  "modified_by": "Administrator",
  "module": "Webshop",
  "name": "Website Item",

--- a/webshop/webshop/doctype/website_item/website_item.py
+++ b/webshop/webshop/doctype/website_item/website_item.py
@@ -545,3 +545,32 @@ def make_website_item(doc, save=True):
 	insert_item_to_index(website_item)
 
 	return [website_item.name, website_item.web_item_name]
+
+@frappe.whitelist()
+def has_website_permission_for_website_item(doc, ptype, user, verbose=False):
+	# Check item group permissions for website
+
+	if user == "Administrator":
+		return True
+
+	if frappe.has_permission("Website Item", ptype=ptype, doc=doc, user=user):
+		return True
+
+	if not frappe.db.get_single_value("Webshop Settings", "login_required_to_view_products"):
+		return True
+
+	return False
+
+@frappe.whitelist()
+def has_website_permission_for_item_group(doc, ptype, user, verbose=False):
+	# Check item group permissions for website
+	if user == "Administrator":
+		return True
+
+	if frappe.has_permission("Item Group", ptype=ptype, doc=doc, user=user):
+		return True
+
+	if not frappe.db.get_single_value("Webshop Settings", "login_required_to_view_products"):
+		return True
+
+	return False


### PR DESCRIPTION
Without login getting 404 error

<img width="471" alt="image" src="https://github.com/user-attachments/assets/370e70f8-d0b4-452b-aabd-c234773b8a84">


**After fix**

Users no need to login to see products

In case if users wants to restrict then they can enable "Login Required to View Products" in the Webshop Settings

<img width="1203" alt="image" src="https://github.com/user-attachments/assets/30f44b73-c88b-4eeb-8472-32934969178d">


