### PR TITLE
copy_specification_from_item_group is not whitelisted

### DIFF
--- a/webshop/webshop/doctype/website_item/website_item.py
+++ b/webshop/webshop/doctype/website_item/website_item.py
@@ -346,6 +346,7 @@ class WebsiteItem(WebsiteGenerator):
 			self.item_code, skip_quotation_creation=True
 		)
 
+	@frappe.whitelist()
 	def copy_specification_from_item_group(self):
 		self.set("website_specifications", [])
 		if self.item_group:


### PR DESCRIPTION
in website item,"Copy From Item Group" calls it and should be whitelisted
![image](https://github.com/user-attachments/assets/0a1811e7-adad-41ac-97da-9d311cd8913b)
