### PR TITLE
fix: AttributeError: 'str' object has no attribute 'customer_address'

### DIFF
--- a/webshop/webshop/shopping_cart/cart.py
+++ b/webshop/webshop/shopping_cart/cart.py
@@ -42,7 +42,7 @@ def get_cart_quotation(doc=None):
 
 	addresses = get_address_docs(party=party)
 
-	if not doc.customer_address and addresses:
+	if not doc.get("customer_address") and addresses:
 		update_cart_address("billing", addresses[0].name)
 
 	return {


### PR DESCRIPTION
  File "apps/webshop/webshop/webshop/shopping_cart/cart.py", line 45, in get_cart_quotation
    if not doc.customer_address and addresses:
AttributeError: 'str' object has no attribute 'customer_address'