### PR TITLE
fix: show the payment button based on the webshop checkout configuration

### DIFF
--- a/webshop/templates/pages/order.html
+++ b/webshop/templates/pages/order.html
@@ -37,7 +37,8 @@
 		<div class="form-column col-sm-6">
 			<div class="page-header-actions-block" data-html-block="header-actions">
 				<p>
-					{% if doc.doctype != "Sales Invoice" or doc.outstanding_amount > 0 %}
+					{% set is_enabled_checkout = (frappe.db.get_value("Webshop Settings","Webshop Settings", "enable_checkout") | int )%}
+					{% if is_enabled_checkout and (doc.doctype != "Sales Invoice" or doc.outstanding_amount > 0) %}
 					<a href="/api/method/erpnext.accounts.doctype.payment_request.payment_request.make_payment_request?dn={{ doc.name }}&dt={{ doc.doctype }}&submit_doc=1&order_type=Shopping Cart"
 						class="btn btn-primary btn-sm" id="pay-for-order">
 						{{ _("Pay") }} {{doc.get_formatted("grand_total") }}


### PR DESCRIPTION
issue: based on checkout configuration, the payment option does not appear correctly.

fix: Use checkout configuration to enable payment.

ref: [29459](https://support.frappe.io/helpdesk/tickets/29459)

Before:

[issue_.webm](https://github.com/user-attachments/assets/f8827208-ac83-4533-8f75-7f0718c8ad92)


After:

[fix_.webm](https://github.com/user-attachments/assets/f5b24322-81a8-4b5c-9136-335a7dc25e3c)


backport needed: v15