### PR TITLE
fix(payment-gateway): allow account with Phone as payment channel

### DIFF
--- a/webshop/webshop/doctype/webshop_settings/webshop_settings.js
+++ b/webshop/webshop/doctype/webshop_settings/webshop_settings.js
@@ -9,7 +9,9 @@ frappe.ui.form.on("Webshop Settings", {
 		}
 
 		frm.set_query('payment_gateway_account', function() {
-			return { 'filters': { 'payment_channel': "Email" } };
+			return { 'filters': { 
+				'payment_channel': ['in', ["Email", "Phone"]] 
+			 } };
 		});
 	},
 	refresh: function(frm) {


### PR DESCRIPTION
Allow Payment Gateway Account whose payment channel is also phone. This will help to initiate transaction with mpesa.
![image](https://github.com/user-attachments/assets/79f77711-dc9c-4571-b569-658600177d11)
Fixing Issue #255 