### PR TITLE
fix: Changes to Item Template Fields Are Not Copied To Variants

### DIFF
--- a/webshop/webshop/doctype/override_doctype/item.py
+++ b/webshop/webshop/doctype/override_doctype/item.py
@@ -9,6 +9,7 @@ class DataValidationError(frappe.ValidationError):
 
 class WebshopItem(Item):
 	def on_update(self):
+		super(WebshopItem, self).on_update()
 		invalidate_cache_for_item(self)
 
 	def before_rename(self, old_name, new_name, merge=False):


### PR DESCRIPTION
This fixes #62.

(Not sure why the diff shows another "change" at the end of `webshop/webshop/doctype/override_doctype/item.py`, only the top insertion under `on_update` was done.)