### PR TITLE
feat: configuration for non-web items in cart quotation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         run: echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
 
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt') }}
@@ -64,7 +64,7 @@ jobs:
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -79,7 +79,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/webshop/webshop/crud_events/quotation/validate_shopping_cart_items.py
+++ b/webshop/webshop/crud_events/quotation/validate_shopping_cart_items.py
@@ -6,6 +6,7 @@ def execute(doc, method=None):
     if doc.order_type != "Shopping Cart":
         return
 
+    webshop_settings = frappe.get_cached_doc("Webshop Settings")
     for item in doc.items:
         has_web_item = frappe.db.exists("Website Item", {"item_code": item.item_code})
 
@@ -14,7 +15,7 @@ def execute(doc, method=None):
         if template and not has_web_item:
             has_web_item = frappe.db.exists("Website Item", {"item_code": template})
 
-        if not has_web_item:
+        if not has_web_item and not webshop_settings.allow_non_website_items_in_cart_quotation:
             frappe.throw(
                 _(
                     "Row #{0}: Item {1} must have a Website Item for Shopping Cart Quotations"

--- a/webshop/webshop/doctype/webshop_settings/webshop_settings.json
+++ b/webshop/webshop/doctype/webshop_settings/webshop_settings.json
@@ -32,6 +32,7 @@
   "column_break_21",
   "default_customer_group",
   "quotation_series",
+  "allow_non_website_items_in_cart_quotation",
   "checkout_settings_section",
   "enable_checkout",
   "show_price_in_quotation",
@@ -373,12 +374,20 @@
    "fieldname": "login_required_to_view_products",
    "fieldtype": "Check",
    "label": "Login Required to View Products"
+  },
+  {
+   "default": "0",
+   "depends_on": "enabled",
+   "fieldname": "allow_non_website_items_in_cart_quotation",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Allow Non Website Items in Cart Quotation"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-12-16 16:22:51.445190",
+ "modified": "2025-03-22 13:01:51.906319",
  "modified_by": "Administrator",
  "module": "Webshop",
  "name": "Webshop Settings",


### PR DESCRIPTION
Currently if we try to add an item which is not associated with a website item to a quotation of type shopping cart, it throws an error and does not allow doing so. This PR introduces a new setting to configure this behaviour. The user might want to add more items to the quotation, which are not in the website.

<img width="1044" alt="Screenshot 2025-03-22 at 2 55 00 PM" src="https://github.com/user-attachments/assets/fbab2dac-1c8b-4f78-820f-c0072b210c85" />


