### PR TITLE
hot-fix: differentiate 'Add to Cart' and 'Go to Cart' buttons by using separate class names

### DIFF
--- a/webshop/public/js/product_ui/list.js
+++ b/webshop/public/js/product_ui/list.js
@@ -193,7 +193,7 @@ webshop.ProductList = class {
 
 				<a href="/cart">
 					<div id="${ item.name }" class="btn
-						btn-sm btn-primary btn-add-to-cart-list
+						btn-sm btn-primary btn-go-to-cart-list
 						ml-4 go-to-cart mb-0 mt-0
 						${ item.in_cart ? '' : 'hidden' }"
 						data-item-code="${ item.item_code }"


### PR DESCRIPTION
This PR addresses a small but important issue regarding the behavior of the "Add to Cart" and "Go to Cart" buttons.

Problem: Both buttons shared the same class and properties, making it difficult to differentiate between them and apply specific functions. Specifically, when the "Go to Cart" button was clicked, the logic for the "Add to Cart" button was still being triggered, causing the cart-checking logic to execute incorrectly.

Solution: I have updated the button logic to distinguish between the "Add to Cart" and "Go to Cart" buttons by modifying the class names and event handlers.

Functionality:

When the "Add to Cart" button is clicked, the function checks if the cart already contains an item. If not, it adds the product to the cart.

When the "Go to Cart" button is clicked, it triggers the Go to Cart function, without interfering with the "Add to Cart" logic.

This allows for correct behavior based on which button is pressed.

Technical Details:

I updated the classes for the "Add to Cart" and "Go to Cart" buttons to make them distinct.

The logic ensures that only the appropriate function is triggered when each button is clicked, avoiding unwanted cart-checking when navigating to the cart.

Impact:

This change resolves the issue of the cart-checking logic being incorrectly triggered when navigating to the cart.

Users can now smoothly add items to the cart and go to the cart without interference between the two actions.

@rmehta 

[Screencast from 02-05-25 04:33:19 PM IST.webm](https://github.com/user-attachments/assets/2b99731b-0fd5-4b02-8154-8bb372c4c9e8)



