### PR TITLE
fix: installation failure

### DIFF
--- a/webshop/patches/copy_custom_field_filters_to_website_item.py
+++ b/webshop/patches/copy_custom_field_filters_to_website_item.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
 
+from webshop.webshop.utils.setup import has_ecommerce_fields
 
 def execute():
 	"Add Field Filters, that are not standard fields in Website Item, as Custom Fields."
@@ -41,7 +42,9 @@ def execute():
 
 		return table_multiselect_data
 
-	settings = frappe.get_doc("E Commerce Settings")
+	settings_doctype = "E Commerce Settings" if has_ecommerce_fields() else "Webshop Settings"
+
+	settings = frappe.get_doc(settings_doctype)
 
 	if not (settings.enable_field_filters or settings.filter_fields):
 		return

--- a/webshop/patches/populate_e_commerce_settings.py
+++ b/webshop/patches/populate_e_commerce_settings.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe.utils import cint
 
+from webshop.webshop.utils.setup import has_ecommerce_fields
 
 def execute():
 	frappe.reload_doc("webshop", "doctype", "webshop_settings")
@@ -34,7 +35,9 @@ def execute():
 		"save_quotations_as_draft",
 	]
 
-	settings = frappe.get_doc("E Commerce Settings")
+	settings_doctype = "E Commerce Settings" if has_ecommerce_fields() else "Webshop Settings"
+
+	settings = frappe.get_doc(settings_doctype)
 
 	def map_into_e_commerce_settings(doctype, fields):
 		singles = frappe.qb.DocType("Singles")
@@ -63,6 +66,6 @@ def execute():
 		frappe.db.set_value(
 			doctype,
 			{"parent": "Products Settings"},
-			{"parenttype": "E Commerce Settings", "parent": "E Commerce Settings"},
+			{"parenttype": settings_doctype, "parent": settings_doctype},
 			update_modified=False,
 		)

--- a/webshop/setup/install.py
+++ b/webshop/setup/install.py
@@ -4,6 +4,7 @@ import frappe
 from frappe import _
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
+from webshop.webshop.utils.setup import has_ecommerce_fields
 
 def after_install():
 	run_patches()
@@ -46,19 +47,6 @@ def copy_from_ecommerce_settings():
 		)
 
 		query.run()
-
-def has_ecommerce_fields() -> bool:
-	table = frappe.qb.Table("tabSingles")
-	query = (
-		frappe.qb.from_(table)
-		.select(table.field)
-		.where(table.doctype == "E Commerce Settings")
-		.limit(1)
-	)
-
-	data = query.run(as_dict=True)
-	return bool(data)
-
 
 def drop_ecommerce_settings():
 	frappe.delete_doc_if_exists("DocType", "E Commerce Settings", force=True)
@@ -229,12 +217,12 @@ def say_thanks():
 patches = [
 	"create_website_items",
 	"populate_e_commerce_settings",
+	"add_homepage_field",
 	"make_homepage_products_website_items",
 	"fetch_thumbnail_in_website_items",
 	"convert_to_website_item_in_item_card_group_template",
 	"shopping_cart_to_ecommerce",
 	"copy_custom_field_filters_to_website_item",
-	"add_homepage_field"
 ]
 
 def run_patches():

--- a/webshop/setup/install.py
+++ b/webshop/setup/install.py
@@ -6,6 +6,7 @@ from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 
 def after_install():
+	run_add_homepage_field_patch()
 	run_patches()
 	copy_from_ecommerce_settings()
 	drop_ecommerce_settings()
@@ -234,12 +235,21 @@ patches = [
 	"convert_to_website_item_in_item_card_group_template",
 	"shopping_cart_to_ecommerce",
 	"copy_custom_field_filters_to_website_item",
-	"add_homepage_field",
 ]
+
+def run_add_homepage_field_patch():
+	# This is a mandatory patch that needs to be run.
+	# It adds necessary custom fields in the Homepage doctype (for v15) which prevents override/homepage.js from misbehaving
+	frappe.flags.in_patch = True
+
+	try:
+		frappe.get_attr("webshop.patches.add_homepage_field.execute")()
+
+	finally:
+		frappe.flags.in_patch = False
 
 def run_patches():
 	# Customers migrating from v13 to v15 directly need to run all below patches
-
 	if frappe.db.table_exists("Website Item"):
 		return
 

--- a/webshop/setup/install.py
+++ b/webshop/setup/install.py
@@ -234,7 +234,7 @@ patches = [
 	"convert_to_website_item_in_item_card_group_template",
 	"shopping_cart_to_ecommerce",
 	"copy_custom_field_filters_to_website_item",
-	"add_homepage_field_patch"
+	"add_homepage_field"
 ]
 
 def run_patches():

--- a/webshop/setup/install.py
+++ b/webshop/setup/install.py
@@ -6,7 +6,6 @@ from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 
 def after_install():
-	run_add_homepage_field_patch()
 	run_patches()
 	copy_from_ecommerce_settings()
 	drop_ecommerce_settings()
@@ -235,23 +234,11 @@ patches = [
 	"convert_to_website_item_in_item_card_group_template",
 	"shopping_cart_to_ecommerce",
 	"copy_custom_field_filters_to_website_item",
+	"add_homepage_field_patch"
 ]
-
-def run_add_homepage_field_patch():
-	# This is a mandatory patch that needs to be run.
-	# It adds necessary custom fields in the Homepage doctype (for v15) which prevents override/homepage.js from misbehaving
-	frappe.flags.in_patch = True
-
-	try:
-		frappe.get_attr("webshop.patches.add_homepage_field.execute")()
-
-	finally:
-		frappe.flags.in_patch = False
 
 def run_patches():
 	# Customers migrating from v13 to v15 directly need to run all below patches
-	if frappe.db.table_exists("Website Item"):
-		return
 
 	frappe.flags.in_patch = True
 

--- a/webshop/webshop/utils/setup.py
+++ b/webshop/webshop/utils/setup.py
@@ -1,0 +1,13 @@
+import frappe
+
+def has_ecommerce_fields() -> bool:
+	table = frappe.qb.Table("tabSingles")
+	query = (
+		frappe.qb.from_(table)
+		.select(table.field)
+		.where(table.doctype == "E Commerce Settings")
+		.limit(1)
+	)
+
+	data = query.run(as_dict=True)
+	return bool(data)


### PR DESCRIPTION
addresses #305

after #303 the check was removed from `install.py -> run_patches()`, all the patches were being executed and in a few patches the old "E Commerce Settings" doctype was being used without checking whether it existed or not which in turn caused the error.

also the ordering of the execution of patches had to be changed as one of the patches (`make_homepage_products_website_items`) depended on another patch being executed before it (`add_homepage_field`)