### PR TITLE
fix: prevent patch execution if Homepage DocType does not exist

### DIFF
--- a/webshop/patches/make_homepage_products_website_items.py
+++ b/webshop/patches/make_homepage_products_website_items.py
@@ -2,6 +2,8 @@ import frappe
 
 
 def execute():
+	if not frappe.db.exists("DocType", "Homepage"):
+		return
 	homepage = frappe.get_doc("Homepage")
 
 	for row in homepage.products:


### PR DESCRIPTION
this prevented webshop from installing on v16 benches