### PR TITLE
fix: only fetch shipping rules for selling

### DIFF
--- a/webshop/webshop/shopping_cart/cart.py
+++ b/webshop/webshop/shopping_cart/cart.py
@@ -739,7 +739,7 @@ def get_shipping_rules(quotation=None, cart_settings=None):
 				.on(sr.name == sr_country.parent)
 				.select(sr.name)
 				.distinct()
-				.where((sr_country.country == country) & (sr.disabled != 1))
+				.where((sr_country.country == country) & (sr.disabled != 1) & (sr.shipping_rule_type == "Selling"))
 			)
 			result = query.run(as_list=True)
 			shipping_rules = [x[0] for x in result]


### PR DESCRIPTION
Frappe Support Issue: https://support.frappe.io/app/hd-ticket/40275


The user has two shipping rules, one for buying and one for selling.
The shipping rule for buying is automatically getting selected, causing the error.

![image](https://github.com/user-attachments/assets/2cdf6238-5e9b-4ff9-8b4c-3379d1283f1b)
![image](https://github.com/user-attachments/assets/95ea2bcc-24e4-4d39-8779-06c380415841)

