### PR TITLE
fix: redis import issue

### DIFF
--- a/webshop/webshop/redisearch_utils.py
+++ b/webshop/webshop/redisearch_utils.py
@@ -8,8 +8,13 @@ from frappe import _
 from frappe.utils.redis_wrapper import RedisWrapper
 from redis import ResponseError
 from redis.commands.search.field import TagField, TextField
-from redis.commands.search.indexDefinition import IndexDefinition
 from redis.commands.search.suggestion import Suggestion
+
+try:
+	from redis.commands.search.index_definition import IndexDefinition
+except ImportError:
+	from redis.commands.search.indexDefinition import IndexDefinition
+
 
 WEBSITE_ITEM_INDEX = "website_items_index"
 WEBSITE_ITEM_KEY_PREFIX = "website_item:"


### PR DESCRIPTION
While installing webshop after redis version bump on frappe this error occured:
```
...
Error: No module named 'redis.commands.search.indexDefinition''builtins.ImportError: Module import failed for Item Review, the DocType you're trying to open might be deleted.
Error: No module named 'redis.commands.search.indexDefinition'
```

this PR tries to fix that