### PR TITLE
Handle Select fieldtype in product filters

### DIFF
--- a/webshop/webshop/product_data_engine/filters.py
+++ b/webshop/webshop/product_data_engine/filters.py
@@ -68,6 +68,8 @@ class ProductFiltersBuilder:
 				)
 
 				values = list(set(item_values) & link_doctype_values)  # intersection of both
+			elif df.fieldtype == "Select":
+				values = df.options.split("\n")
 			else:
 				# table multiselect
 				values = list(link_doctype_values)


### PR DESCRIPTION
Currently, it is only possible to use fields of type Link or Multiselect as filters for article groups. With this pr, it is now also possible to use fields of type Select as filters. The values displayed are the defined options of the field. This also works for custom fields. The change in the code is minimal, but the benefit for the user is big. The following issues have been fixed:

- https://github.com/frappe/webshop/issues/244
- https://github.com/frappe/webshop/issues/181

Before:
![Bildschirmfoto 2025-07-04 um 12 16 31](https://github.com/user-attachments/assets/2c1c79a8-000e-4188-bb25-bce5ad252d91)

After:
![Bildschirmfoto 2025-07-04 um 12 04 25](https://github.com/user-attachments/assets/898588a3-880e-4e6a-ad52-a4083a2ead56)

Setup:
1. Create a new custom Select field for the website item doctype with options or use an existing Select field:
![Bildschirmfoto 2025-07-04 um 12 07 24](https://github.com/user-attachments/assets/aaa0d565-5200-44de-81ac-fe55ab01610b)

2. Define the Select field as an item filter in the website group: 
![Bildschirmfoto 2025-07-04 um 12 05 14](https://github.com/user-attachments/assets/a70cde06-5d1f-446e-b5f1-bc46e6b2d9b5)

