### PR TITLE
fix: Update Redis import to use correct module name

### DIFF
--- a/webshop/webshop/redisearch_utils.py
+++ b/webshop/webshop/redisearch_utils.py
@@ -8,7 +8,7 @@ from frappe import _
 from frappe.utils.redis_wrapper import RedisWrapper
 from redis import ResponseError
 from redis.commands.search.field import TagField, TextField
-from redis.commands.search.indexDefinition import IndexDefinition
+from redis.commands.search.index_definition import IndexDefinition
 from redis.commands.search.suggestion import Suggestion
 
 WEBSITE_ITEM_INDEX = "website_items_index"


### PR DESCRIPTION
   ## Description
   Fixes #317: ImportError for redis.commands.search.indexDefinition
   
   ## Changes Made
   - Updated import statement from `redis.commands.search.indexDefinition` to `redis.commands.search.index_definition`
   - This resolves compatibility issues with newer Redis versions
   
   ## Related Issue
   Closes #317