### PR TITLE
fix: handle first-time item insertion during comparison

### DIFF
--- a/webshop/webshop/crud_events/item/update_website_item.py
+++ b/webshop/webshop/crud_events/item/update_website_item.py
@@ -16,6 +16,8 @@ def execute(doc, method=None):
             "disabled",
         ]
         doc_before_save = doc.get_doc_before_save()
+        if not doc_before_save:
+            return
 
         for field in editable_fields:
             if doc_before_save.get(field) != doc.get(field):


### PR DESCRIPTION
## Summary

This PR fixes an issue where the website item update logic fails for newly created Items because it attempts to compare the current document with a previous version that does not exist.

## Root Cause

During the initial insert, there is no previous document available. The existing comparison logic assumes one exists, resulting in an exception.

## Solution

* Added a guard condition to detect first-time inserts.
* Skip the comparison when no previous document is available.
* Preserve the existing comparison behavior for document updates.

## Testing

* ✅ Created a new Item and verified that no exception is raised.
* ✅ Updated an existing Item and verified that the comparison logic continues to work as expected.
* ✅ Confirmed that existing functionality remains unchanged for update operations.

Fixes issue [Issue no 367](https://github.com/frappe/webshop/issues/367)