### PR TITLE
chore: convert db.sql calls for broader database support

### DIFF
--- a/webshop/webshop/doctype/override_doctype/item_group.py
+++ b/webshop/webshop/doctype/override_doctype/item_group.py
@@ -120,14 +120,7 @@ def get_parent_item_groups(item_group_name, from_item=False):
 		return base_parents
 
 	item_group = frappe.db.get_value("Item Group", item_group_name, ["lft", "rgt"], as_dict=1)
-	parent_groups = frappe.db.sql(
-		"""select name, route from `tabItem Group`
-		where lft <= %s and rgt >= %s
-		and show_in_website=1
-		order by lft asc""",
-		(item_group.lft, item_group.rgt),
-		as_dict=True,
-	)
+	parent_groups = frappe.get_all( "Item Group", filters=[['lft', '<=', item_group.lft], ['rgt', '>=', item_group.rgt], ['show_in_website', '=', 1]], fields=["name", "route"], order_by="lft asc" )
 
 	return base_parents + parent_groups
 

--- a/webshop/webshop/doctype/override_doctype/item_group.py
+++ b/webshop/webshop/doctype/override_doctype/item_group.py
@@ -120,7 +120,15 @@ def get_parent_item_groups(item_group_name, from_item=False):
 		return base_parents
 
 	item_group = frappe.db.get_value("Item Group", item_group_name, ["lft", "rgt"], as_dict=1)
-	parent_groups = frappe.get_all( "Item Group", filters=[['lft', '<=', item_group.lft], ['rgt', '>=', item_group.rgt], ['show_in_website', '=', 1]], fields=["name", "route"], order_by="lft asc" )
+	parent_groups = frappe.get_all(
+		"Item Group",
+		filters=[
+				['lft', '<=', item_group.lft],
+				['rgt', '>=', item_group.rgt],
+				['show_in_website', '=', 1]],
+		fields=["name", "route"],
+		order_by="lft asc",
+	)
 
 	return base_parents + parent_groups
 

--- a/webshop/webshop/doctype/webshop_settings/test_webshop_settings.py
+++ b/webshop/webshop/doctype/webshop_settings/test_webshop_settings.py
@@ -14,7 +14,7 @@ class TestWebshopSettings(unittest.TestCase):
 		frappe.db.rollback()
 
 	def test_tax_rule_validation(self):
-		frappe.db.sql("update `tabTax Rule` set use_for_shopping_cart = 0")
+		frappe.db.set_value("Tax Rule", {}, "use_for_shopping_cart", 0, update_modified=False)
 		frappe.db.commit()  # nosemgrep
 
 		cart_settings = frappe.get_doc("Webshop Settings")
@@ -22,7 +22,7 @@ class TestWebshopSettings(unittest.TestCase):
 		if not frappe.db.get_value("Tax Rule", {"use_for_shopping_cart": 1}, "name"):
 			self.assertRaises(ShoppingCartSetupError, cart_settings.validate_tax_rule)
 
-		frappe.db.sql("update `tabTax Rule` set use_for_shopping_cart = 1")
+		frappe.db.set_value("Tax Rule", {}, "use_for_shopping_cart", 1, update_modified=False)
 
 	def test_invalid_filter_fields(self):
 		"Check if Item fields are blocked in Webshop Settings filter fields."

--- a/webshop/webshop/doctype/website_item/test_website_item.py
+++ b/webshop/webshop/doctype/website_item/test_website_item.py
@@ -81,14 +81,12 @@ class TestWebsiteItem(unittest.TestCase):
 		from webshop.webshop.doctype.website_item.website_item import on_doctype_update
 
 		on_doctype_update()
+		
+		expected_columns = {"route_index", "item_group", "brand"}  # add_index in on_doctype_update adds "_index" to "route" for its index name
+		missing = {col for col in expected_columns if not frappe.db.has_index("tabWebsite Item", col)}
 
-		indices = frappe.db.sql("show index from `tabWebsite Item`", as_dict=1)
-		expected_columns = {"route", "item_group", "brand"}
-		for index in indices:
-			expected_columns.discard(index.get("Column_name"))
-
-		if expected_columns:
-			self.fail(f"Expected db index on these columns: {', '.join(expected_columns)}")
+		if missing:
+			self.fail(f"Expected db index on these columns: {', '.join(missing)}")
 
 	def test_website_item_desk_item_sync(self):
 		"Check creation/updation/deletion of Website Item and its impact on Item master."

--- a/webshop/webshop/shopping_cart/test_shopping_cart.py
+++ b/webshop/webshop/shopping_cart/test_shopping_cart.py
@@ -42,7 +42,7 @@ class TestShoppingCart(unittest.TestCase):
 
 	@classmethod
 	def tearDownClass(cls):
-		frappe.db.sql("delete from `tabTax Rule`")
+		frappe.db.delete("Tax Rule")
 
 	def test_get_cart_new_user(self):
 		self.login_as_customer(

--- a/webshop/webshop/utils/product.py
+++ b/webshop/webshop/utils/product.py
@@ -3,6 +3,7 @@ from frappe.utils import getdate, nowdate
 
 from erpnext.stock.doctype.batch.batch import get_batch_qty
 from erpnext.stock.doctype.warehouse.warehouse import get_child_warehouses
+from frappe.query_builder.functions import Coalesce
 
 
 def get_web_item_qty_in_stock(item_code, item_warehouse_field, warehouse=None):
@@ -26,16 +27,19 @@ def get_web_item_qty_in_stock(item_code, item_warehouse_field, warehouse=None):
 
 	total_stock = 0.0
 	if warehouses:
-		for warehouse in warehouses:
-			stock_qty = frappe.db.sql(
-				"""
-				select S.actual_qty / IFNULL(C.conversion_factor, 1)
-				from tabBin S
-				inner join `tabItem` I on S.item_code = I.Item_code
-				left join `tabUOM Conversion Detail` C on I.sales_uom = C.uom and C.parent = I.Item_code
-				where S.item_code=%s and S.warehouse=%s""",
-				(item_code, warehouse),
-			)
+		s = frappe.qb.DocType("Bin")
+		i = frappe.qb.DocType("Item")
+		c = frappe.qb.DocType("UOM Conversion Detail")
+		for warehouse in warehouses:	
+			stock_qty = (
+				frappe.qb.from_(s)
+				.inner_join(i)
+				.on(s.item_code == i.item_code)
+				.left_join(c)
+				.on((i.sales_uom == c.uom) & (c.parent == i.item_code))
+				.select((s.actual_qty / Coalesce(c.conversion_factor, 1)))
+				.where((s.item_code == item_code) & (s.warehouse == warehouse))
+			).run()
 
 			if stock_qty:
 				total_stock += adjust_qty_for_expired_items(item_code, stock_qty, warehouse)


### PR DESCRIPTION
Hi folks,

I'm a member of the [AgriTheory team](https://github.com/agritheory/), which maintains a number of Frappe and ERPNext apps. We're in the process of migrating our apps to version-16, and part of that process is updating any SQL queries in the code to support PostgreSQL in addition to MariaDB. As some of our apps use other Frappe apps as a dependency, we figured we'd help in the effort here.

This PR converts a few remaining lines of `frappe.db.sql` calls and MariaDB-specific syntax in the code base and tests into database-agnostic code. This included two refactors in the code base and four areas in tests.

Note that there is an example in a patch (located in [line 40 of create_website_items.py](https://github.com/frappe/webshop/blob/develop/webshop/patches/create_website_items.py#L40)) that wasn't updated given the age of the file and the nature that patches run once, but happy to update that if needed.

