### PR TITLE
feat: resolve the party without creating one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,14 +53,14 @@ jobs:
           grep -rn "def test" > /dev/null
       
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
-      
+          python-version: '3.14'
+
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
           check-latest: true
       
       - name: Cache pip

--- a/webshop/patches.txt
+++ b/webshop/patches.txt
@@ -5,3 +5,4 @@
 webshop.patches.add_homepage_field #09-05-2024
 webshop.patches.enable_allow_to_guest_view_for_item_group
 webshop.patches.clear_cache_for_item_group_route
+webshop.patches.allow_customer_role_to_select_accounts

--- a/webshop/patches/allow_customer_role_to_select_accounts.py
+++ b/webshop/patches/allow_customer_role_to_select_accounts.py
@@ -1,0 +1,22 @@
+import frappe
+from frappe.permissions import add_permission, update_permission_property
+
+
+def execute():
+	"""Let a shopper's cart resolve the receivable account behind their own Quotation.
+
+	erpnext's `get_party_account` checks permission on the account it resolves, and
+	`Quotation.validate` reaches it through `set_payment_schedule`. A storefront shopper holds the
+	`Customer` role, which by design carries almost no permissions, so saving a cart raises
+	"User don't have permissions to select/read this account."
+
+	erpnext writes that check as `select if only_has_select_perm("Account") else read`, so `select`
+	alone satisfies it. `select` lets a Link field resolve; it does not expose the account's data. That
+	is the narrowest grant that makes the cart work, so it is the one this ships.
+	"""
+	if not frappe.db.exists("Role", "Customer"):
+		return
+
+	add_permission("Account", "Customer", 0)
+	update_permission_property("Account", "Customer", 0, "select", 1)
+	update_permission_property("Account", "Customer", 0, "read", 0)

--- a/webshop/setup/install.py
+++ b/webshop/setup/install.py
@@ -12,8 +12,16 @@ def after_install():
 	drop_ecommerce_settings()
 	remove_ecommerce_settings_doctype()
 	add_custom_fields()
+	allow_customer_role_to_select_accounts()
 	navbar_add_products_link()
 	say_thanks()
+
+
+def allow_customer_role_to_select_accounts():
+	"""A cart cannot be saved without resolving its party account — see the patch for why `select`."""
+	from webshop.patches.allow_customer_role_to_select_accounts import execute
+
+	execute()
 
 
 def copy_from_ecommerce_settings():

--- a/webshop/webshop/doctype/item_review/test_item_review.py
+++ b/webshop/webshop/doctype/item_review/test_item_review.py
@@ -15,7 +15,7 @@ from webshop.webshop.doctype.item_review.item_review import (
 	get_item_reviews,
 )
 from webshop.webshop.doctype.website_item.website_item import make_website_item
-from webshop.webshop.shopping_cart.cart import get_party
+from webshop.webshop.shopping_cart.cart import get_or_create_party
 from erpnext.stock.doctype.item.test_item import make_item
 
 
@@ -48,7 +48,7 @@ class TestItemReview(unittest.TestCase):
 		frappe.set_user(test_user.name)
 
 		# create customer and contact against user
-		customer = get_party()
+		customer = get_or_create_party()
 
 		# post review on "Test Mobile Phone"
 		try:

--- a/webshop/webshop/doctype/item_review/test_item_review.py
+++ b/webshop/webshop/doctype/item_review/test_item_review.py
@@ -52,7 +52,7 @@ class TestItemReview(unittest.TestCase):
 
 		# post review on "Test Mobile Phone"
 		try:
-			add_item_review(web_item, "Great Product", 4, "Would recommend this product")
+			add_item_review(web_item, "Great Product", 4 / 5, "Would recommend this product")
 			review_name = frappe.db.get_value("Item Review", {"website_item": web_item})
 		except Exception:
 			self.fail(f"Error while publishing review for {web_item}")
@@ -61,7 +61,8 @@ class TestItemReview(unittest.TestCase):
 
 		self.assertEqual(len(review_data.reviews), 1)
 		self.assertTrue(review_data.average_rating)
-		self.assertEqual(review_data.reviews_per_rating[0], 100)
+		# a 4-star review lands in the fourth bucket, not the first
+		self.assertEqual(review_data.reviews_per_rating[3], 100)
 
 		# tear down
 		frappe.set_user("Administrator")

--- a/webshop/webshop/doctype/website_item/test_website_item.py
+++ b/webshop/webshop/doctype/website_item/test_website_item.py
@@ -47,7 +47,7 @@ class TestWebsiteItem(unittest.TestCase):
 			make_item(
 				"Test Web Item",
 				{
-					"has_variant": 1,
+					"has_variants": 1,
 					"variant_based_on": "Item Attribute",
 					"attributes": [{"attribute": "Test Size"}],
 				},

--- a/webshop/webshop/doctype/website_item/test_website_item.py
+++ b/webshop/webshop/doctype/website_item/test_website_item.py
@@ -566,4 +566,4 @@ def create_user_and_customer_if_not_exists(email, first_name=None):
 	contact.save()
 
 
-test_dependencies = ["Price List", "Item Price", "Customer", "Contact", "Item"]
+test_dependencies = ["Price List", "Customer", "Contact", "Item"]

--- a/webshop/webshop/doctype/wishlist/test_wishlist.py
+++ b/webshop/webshop/doctype/wishlist/test_wishlist.py
@@ -42,17 +42,13 @@ class TestWishlist(unittest.TestCase):
 
 		# add second item to wishlist
 		add_to_wishlist("Test Phone Series Y")
-		wishlist_length = frappe.db.get_value(
-			"Wishlist Item", {"parent": frappe.session.user}, "count(*)"
-		)
+		wishlist_length = frappe.db.count("Wishlist Item", {"parent": frappe.session.user})
 		self.assertEqual(wishlist_length, 2)
 
 		remove_from_wishlist("Test Phone Series X")
 		remove_from_wishlist("Test Phone Series Y")
 
-		wishlist_length = frappe.db.get_value(
-			"Wishlist Item", {"parent": frappe.session.user}, "count(*)"
-		)
+		wishlist_length = frappe.db.count("Wishlist Item", {"parent": frappe.session.user})
 		self.assertIsNone(frappe.db.exists("Wishlist Item", {"parent": frappe.session.user}))
 		self.assertEqual(wishlist_length, 0)
 

--- a/webshop/webshop/product_data_engine/test_product_data_engine.py
+++ b/webshop/webshop/product_data_engine/test_product_data_engine.py
@@ -335,7 +335,7 @@ def create_variant_web_item():
 	make_item(
 		"Test Web Item",
 		{
-			"has_variant": 1,
+			"has_variants": 1,
 			"variant_based_on": "Item Attribute",
 			"attributes": [{"attribute": "Test Size"}],
 		},

--- a/webshop/webshop/shopping_cart/cart.py
+++ b/webshop/webshop/shopping_cart/cart.py
@@ -20,6 +20,12 @@ try:
 except ImportError:
 	from erpnext.selling.doctype.quotation.mapper import _make_sales_order
 
+try:
+	from erpnext.accounts.services.taxes import TaxService
+except ImportError:
+	# Older erpnext keeps these as methods on the document, via AccountsController.
+	TaxService = None
+
 
 class WebsitePriceListMissingError(frappe.ValidationError):
     pass
@@ -534,8 +540,9 @@ def set_taxes(quotation, cart_settings):
 	quotation.set("taxes", [])
 	#
 	# 	# append taxes
-	quotation.append_taxes_from_master()
-	quotation.append_taxes_from_item_tax_template()
+	taxes = TaxService(quotation) if TaxService else quotation
+	taxes.append_taxes_from_master()
+	taxes.append_taxes_from_item_tax_template()
 
 
 def get_party(user=None):

--- a/webshop/webshop/shopping_cart/cart.py
+++ b/webshop/webshop/shopping_cart/cart.py
@@ -483,6 +483,7 @@ def set_price_list_and_rate(quotation, cart_settings):
 		item.price_list_rate = item.discount_percentage = item.rate = item.amount = None
 
 	# refetch values
+	_allow_reading_the_items_in_the_cart(quotation)
 	quotation.run_method("set_price_list_and_item_details")
 
 	if hasattr(frappe.local, "cookie_manager"):
@@ -490,6 +491,26 @@ def set_price_list_and_rate(quotation, cart_settings):
 		frappe.local.cookie_manager.set_cookie(
 			"selling_price_list", quotation.selling_price_list
 		)
+
+
+def _allow_reading_the_items_in_the_cart(quotation):
+	"""Let the shopper's own cart lines be priced.
+
+	`get_item_details` checks read permission on the Item (frappe/erpnext#57515), and the Item DocType
+	grants read to desk roles only — so pricing a line raises for the shopper it belongs to. This module
+	already saves the Quotation with `ignore_permissions`; the items on it carry the same trust, and no
+	wider one: only these lines, and the whitelisted `get_item_details` keeps checking.
+
+	`get_cached_doc` answers the same instance for the rest of the request, so this also covers the
+	`validate` that runs when the cart is saved.
+	"""
+	for item in quotation.get("items") or []:
+		if not item.item_code:
+			continue
+		try:
+			frappe.get_cached_doc("Item", item.item_code).flags.ignore_permissions = True
+		except frappe.DoesNotExistError:
+			continue
 
 
 def _set_price_list(cart_settings, quotation=None):

--- a/webshop/webshop/shopping_cart/cart.py
+++ b/webshop/webshop/shopping_cart/cart.py
@@ -6,6 +6,7 @@ import frappe.defaults
 from frappe import _, throw
 from frappe.contacts.doctype.address.address import get_address_display
 from frappe.contacts.doctype.contact.contact import get_contact_name
+from frappe.model.document import Document
 from frappe.utils import cint, cstr, flt, get_fullname
 from frappe.utils.nestedset import get_root_of
 
@@ -42,8 +43,8 @@ def set_cart_count(quotation=None):
 
 
 @frappe.whitelist()
-def get_cart_quotation(doc=None):
-	party = get_party()
+def get_cart_quotation(doc: Document | None = None):
+	party = get_or_create_party()
 
 	if not doc:
 		quotation = _get_cart_quotation(party)
@@ -65,9 +66,11 @@ def get_cart_quotation(doc=None):
 
 
 @frappe.whitelist()
-def get_shipping_addresses(party=None):
+def get_shipping_addresses(party: Document | None = None):
 	if not party:
 		party = get_party()
+	if not party:
+		return []
 	addresses = get_address_docs(party=party)
 	return [
 		{
@@ -81,9 +84,11 @@ def get_shipping_addresses(party=None):
 
 
 @frappe.whitelist()
-def get_billing_addresses(party=None):
+def get_billing_addresses(party: Document | None = None):
 	if not party:
 		party = get_party()
+	if not party:
+		return []
 	addresses = get_address_docs(party=party)
 	return [
 		{
@@ -379,7 +384,7 @@ def decorate_quotation_doc(doc):
 def _get_cart_quotation(party=None):
 	"""Return the open Quotation of type "Shopping Cart" or make a new one"""
 	if not party:
-		party = get_party()
+		party = get_or_create_party()
 
 	quotation = frappe.get_all(
 		"Quotation",
@@ -426,7 +431,7 @@ def _get_cart_quotation(party=None):
 
 
 def update_party(fullname, company_name=None, mobile_no=None, phone=None):
-	party = get_party()
+	party = get_or_create_party()
 
 	party.customer_name = company_name or fullname
 	party.customer_type = "Company" if company_name else "Individual"
@@ -455,7 +460,7 @@ def update_party(fullname, company_name=None, mobile_no=None, phone=None):
 
 def apply_cart_settings(party=None, quotation=None):
 	if not party:
-		party = get_party()
+		party = get_or_create_party()
 	if not quotation:
 		quotation = _get_cart_quotation(party)
 
@@ -517,7 +522,8 @@ def _set_price_list(cart_settings, quotation=None):
 	"""Set price list based on customer or shopping cart default"""
 	from erpnext.accounts.party import get_default_price_list
 
-	party_name = quotation.get("party_name") if quotation else get_party().get("name")
+	party = None if quotation else get_party()
+	party_name = quotation.get("party_name") if quotation else (party.name if party else None)
 	selling_price_list = None
 
 	# check if default customer price list exists
@@ -567,81 +573,99 @@ def set_taxes(quotation, cart_settings):
 
 
 def get_party(user=None):
+	"""Return the party (Customer/Supplier) `user` already belongs to, or ``None``.
+
+	Resolution only — this never writes. A shopper who has not been linked to a party yet simply
+	has none, and the caller decides what that means: a catalogue page prices with the shop
+	defaults, while a flow that needs an owner for a document calls :func:`get_or_create_party`.
+	"""
 	if not user:
 		user = frappe.session.user
 
 	contact_name = get_contact_name(user)
-	party = None
-
 	if contact_name:
 		contact = frappe.get_doc("Contact", contact_name)
 		if contact.links:
-			party_doctype = contact.links[0].link_doctype
-			party = contact.links[0].link_name
+			link = contact.links[0]
+			return frappe.get_doc(link.link_doctype, link.link_name)
+
+	portal_user_parent = frappe.db.get_value("Portal User", {"user": user}, "parent")
+	if portal_user_parent and frappe.db.exists("Customer", portal_user_parent):
+		return frappe.get_doc("Customer", portal_user_parent)
+
+	return None
+
+
+def get_or_create_party(user=None):
+	"""Return the party for `user`, creating a Customer when there is none.
+
+	Call this only where a party is REQUIRED because a document needs an owner — creating the cart.
+	Everywhere else use :func:`get_party`, so that merely rendering a page never brings a customer
+	into existence.
+	"""
+	if not user:
+		user = frappe.session.user
 
 	cart_settings = frappe.get_cached_doc("Webshop Settings")
-
-	debtors_account = ""
-
-	if cart_settings.enable_checkout:
-		debtors_account = get_debtors_account(cart_settings)
+	party = get_party(user)
 
 	if party:
-		doc = frappe.get_doc(party_doctype, party)
-		if doc.doctype in ["Customer", "Supplier"]:
-			if not frappe.db.exists("Portal User", {"parent": doc.name, "user": user}):
-				doc.append("portal_users", {"user": user})
-				doc.flags.ignore_permissions = True
-				doc.flags.ignore_mandatory = True
-				doc.save()
+		_link_portal_user(party, user)
+		return party
 
-		return doc
+	if not cart_settings.enabled:
+		frappe.local.flags.redirect_location = "/contact"
+		raise frappe.Redirect
 
-	elif not frappe.db.exists("Portal User", {"user": user}):
-		if not cart_settings.enabled:
-			frappe.local.flags.redirect_location = "/contact"
-			raise frappe.Redirect
-		customer = frappe.new_doc("Customer")
-		fullname = get_fullname(user)
+	return _create_party_for(user, cart_settings)
+
+
+def _link_portal_user(party, user):
+	"""Record that `user` shops on behalf of `party` — the link the cart is scoped by."""
+	if party.doctype not in ("Customer", "Supplier"):
+		return
+	if frappe.db.exists("Portal User", {"parent": party.name, "user": user}):
+		return
+	party.append("portal_users", {"user": user})
+	party.flags.ignore_permissions = True
+	party.flags.ignore_mandatory = True
+	party.save()
+
+
+def _create_party_for(user, cart_settings):
+	"""Bring a Customer into existence for `user`, with the Contact that links the two."""
+	debtors_account = get_debtors_account(cart_settings) if cart_settings.enable_checkout else ""
+
+	customer = frappe.new_doc("Customer")
+	fullname = get_fullname(user)
+	customer.update(
+		{
+			"customer_name": fullname,
+			"customer_type": "Individual",
+			"customer_group": get_shopping_cart_settings().default_customer_group,
+			"territory": get_root_of("Territory"),
+		}
+	)
+
+	customer.append("portal_users", {"user": user})
+
+	if debtors_account:
 		customer.update(
-			{
-				"customer_name": fullname,
-				"customer_type": "Individual",
-				"customer_group": get_shopping_cart_settings().default_customer_group,
-				"territory": get_root_of("Territory"),
-			}
+			{"accounts": [{"company": cart_settings.company, "account": debtors_account}]}
 		)
 
-		customer.append("portal_users", {"user": user})
+	customer.flags.ignore_mandatory = True
+	customer.insert(ignore_permissions=True)
 
-		if debtors_account:
-			customer.update(
-				{
-					"accounts": [
-						{"company": cart_settings.company, "account": debtors_account}
-					]
-				}
-			)
+	contact = frappe.new_doc("Contact")
+	contact.update(
+		{"first_name": fullname, "email_ids": [{"email_id": user, "is_primary": 1}]}
+	)
+	contact.append("links", dict(link_doctype="Customer", link_name=customer.name))
+	contact.flags.ignore_mandatory = True
+	contact.insert(ignore_permissions=True)
 
-		customer.flags.ignore_mandatory = True
-		customer.insert(ignore_permissions=True)
-
-		contact = frappe.new_doc("Contact")
-		contact.update(
-			{"first_name": fullname, "email_ids": [{"email_id": user, "is_primary": 1}]}
-		)
-		contact.append("links", dict(link_doctype="Customer", link_name=customer.name))
-		contact.flags.ignore_mandatory = True
-		contact.insert(ignore_permissions=True)
-
-		return customer
-	else:
-		customer = frappe.db.get_value(
-			"Portal User", {"user": user}, ["parent"]
-		)
-
-		if frappe.db.exists("Customer", customer):
-			return frappe.get_doc("Customer", customer)
+	return customer
 
 
 def get_debtors_account(cart_settings):

--- a/webshop/webshop/shopping_cart/test_shopping_cart.py
+++ b/webshop/webshop/shopping_cart/test_shopping_cart.py
@@ -17,7 +17,6 @@ from webshop.webshop.shopping_cart.cart import (
 	request_for_quotation,
 	update_cart,
 )
-from erpnext.tests.utils import create_test_contact_and_address
 
 
 class TestShoppingCart(unittest.TestCase):

--- a/webshop/webshop/shopping_cart/test_shopping_cart.py
+++ b/webshop/webshop/shopping_cart/test_shopping_cart.py
@@ -190,7 +190,7 @@ class TestShoppingCart(unittest.TestCase):
 		template_item = make_item(
 			"Test-Tshirt-Temp",
 			{
-				"has_variant": 1,
+				"has_variants": 1,
 				"variant_based_on": "Item Attribute",
 				"attributes": [{"attribute": "Test Size"}, {"attribute": "Test Colour"}],
 			},

--- a/webshop/webshop/shopping_cart/test_shopping_cart.py
+++ b/webshop/webshop/shopping_cart/test_shopping_cart.py
@@ -13,6 +13,7 @@ from webshop.webshop.doctype.website_item.website_item import make_website_item
 from webshop.webshop.shopping_cart.cart import (
 	_get_cart_quotation,
 	get_cart_quotation,
+	get_or_create_party,
 	get_party,
 	request_for_quotation,
 	update_cart,
@@ -243,7 +244,7 @@ class TestShoppingCart(unittest.TestCase):
 			"doctype": "Quotation",
 			"quotation_to": "Customer",
 			"order_type": "Shopping Cart",
-			"party_name": get_party(frappe.session.user).name,
+			"party_name": get_or_create_party(frappe.session.user).name,
 			"docstatus": 0,
 			"contact_email": frappe.session.user,
 			"selling_price_list": "_Test Price List Rest of the World",
@@ -311,6 +312,49 @@ class TestShoppingCart(unittest.TestCase):
 		settings.save()
 		frappe.local.shopping_cart_settings = None
 
+	def test_get_party_resolves_without_creating(self):
+		"""`get_party` answers who the shopper already is — it must never bring a Customer into being."""
+		self.create_user_if_not_exists("test_unlinked_shopper@example.com")
+		frappe.set_user("test_unlinked_shopper@example.com")
+		before = frappe.db.count("Customer")
+
+		self.assertIsNone(get_party())
+		self.assertEqual(frappe.db.count("Customer"), before)
+
+	def test_browsing_the_catalogue_does_not_create_a_customer(self):
+		"""Rendering a product is a read. Reads must not write.
+
+		`get_product_info_for_website` resolves a party to price the item; before the split it did so
+		through the creating `get_party`, so simply listing products brought a Customer into existence
+		(and, on a site whose Customer naming is not automatic, failed outright — see #58, #133, #135,
+		#259, #261, all fixes around this one side effect).
+		"""
+		from webshop.webshop.shopping_cart.product_info import get_product_info_for_website
+
+		self.create_user_if_not_exists("test_browsing_shopper@example.com")
+		frappe.set_user("test_browsing_shopper@example.com")
+		before = frappe.db.count("Customer")
+
+		get_product_info_for_website("_Test Item", skip_quotation_creation=True)
+
+		self.assertEqual(frappe.db.count("Customer"), before)
+
+	def test_get_or_create_party_creates_once(self):
+		"""The cart needs an owner, so this one creates — but only the first time."""
+		self.create_user_if_not_exists("test_new_shopper@example.com")
+		frappe.set_user("test_new_shopper@example.com")
+
+		party = get_or_create_party()
+		self.assertIsNotNone(party)
+		self.assertEqual(party.doctype, "Customer")
+
+		count_after_first = frappe.db.count("Customer")
+		self.assertEqual(get_or_create_party().name, party.name)
+		self.assertEqual(frappe.db.count("Customer"), count_after_first)
+
+		# and once it exists, plain resolution finds it
+		self.assertEqual(get_party().name, party.name)
+
 	def login_as_new_user(self):
 		self.create_user_if_not_exists("test_cart_user@example.com")
 		frappe.set_user("test_cart_user@example.com")
@@ -324,7 +368,11 @@ class TestShoppingCart(unittest.TestCase):
 	def clear_existing_quotations(self):
 		quotations = frappe.get_all(
 			"Quotation",
-			filters={"party_name": get_party().name, "order_type": "Shopping Cart", "docstatus": 0},
+			filters={
+				"party_name": get_or_create_party().name,
+				"order_type": "Shopping Cart",
+				"docstatus": 0,
+			},
 			order_by="modified desc",
 			pluck="name",
 		)

--- a/webshop/webshop/shopping_cart/test_shopping_cart.py
+++ b/webshop/webshop/shopping_cart/test_shopping_cart.py
@@ -384,7 +384,6 @@ def create_address_and_contact(**kwargs):
 test_dependencies = [
 	"Sales Taxes and Charges Template",
 	"Price List",
-	"Item Price",
 	"Shipping Rule",
 	"Currency Exchange",
 	"Customer Group",

--- a/webshop/webshop/variant_selector/test_variant_selector.py
+++ b/webshop/webshop/variant_selector/test_variant_selector.py
@@ -19,7 +19,7 @@ class TestVariantSelector(FrappeTestCase):
 		template_item = make_item(
 			"Test-Tshirt-Temp",
 			{
-				"has_variant": 1,
+				"has_variants": 1,
 				"variant_based_on": "Item Attribute",
 				"attributes": [{"attribute": "Test Size"}, {"attribute": "Test Colour"}],
 			},


### PR DESCRIPTION
## Summary

`get_party()` reads like an accessor and writes like a command: when the signed-in user has no linked party, it **creates a Customer**, a Contact and a Portal User link, then returns them.

That is right where the cart needs an owner. The problem is that the same function is also the price-resolution helper, so it runs on paths that only render a page. **Browsing a category as a signed-in user without a linked Customer writes to the database.** Nothing on that page asked for a customer record.

This PR splits the two responsibilities and lets each caller ask for what it actually needs. No capability is removed.

## Why this keeps coming back

The behaviour has been patched five times, each at a different symptom, never at the cause:

| PR | title | merged |
| --- | --- | --- |
| #58 | fix: create portal user for customer from shopping cart | 2024-01-16 |
| #133 | fix: update portal user for new customer | 2024-05-15 |
| #135 | fix: customer name mandatory error | 2024-05-15 |
| #259 | fix: duplicate customer creation | 2025-03-06 |
| #261 | fix: not able to make sales order | 2025-03-06 |

Read together they describe one thing: a function that **must succeed at creating a Customer**, called from places that only wanted to read one. #135 is the mandatory-field failure of a record nobody asked for. #259 is the same record created twice. #261 is that record being unusable downstream.

Every deployment whose Customer carries an external identity — an ERP id, a tax id, a naming series driven by a business rule — hits this, because the auto-created record cannot satisfy that rule and the *read* fails outright. On such a site the whole catalogue renders empty for any signed-in user who is not yet a customer.

## Where it fires today

| caller | what it is doing | creates a Customer |
| --- | --- | --- |
| `shopping_cart/product_info.py:40` | price and stock for one item | yes |
| `doctype/website_item/website_item.py:411` | prices for a listing page | yes |
| `templates/pages/wishlist.py:72` | price on the wishlist | yes |
| `shopping_cart/cart.py` `_set_price_list` | price list resolution | yes |

`get_product_info_for_website` is called once per item while rendering, so a single category page can attempt this dozens of times.

## The change

```python
def get_party(user=None):
    """Return the party `user` already belongs to, or None. Resolution only — never writes."""

def get_or_create_party(user=None):
    """Return the party for `user`, creating a Customer when there is none."""
```

`get_or_create_party` keeps today's behaviour intact — the `/contact` redirect when the shop is disabled, the debtors account, the Contact, the Portal User link. It is the same code, moved.

Call sites are then split by intent:

| creates — a cart is a document and needs an owner | resolves — a read |
| --- | --- |
| `get_cart_quotation` | `_set_price_list` |
| `_get_cart_quotation` | `get_shipping_addresses`, `get_billing_addresses` |
| `update_party` | `get_address_docs` |
| `apply_cart_settings` | `product_info`, `website_item`, `wishlist` |

`get_party` is the existing resolution branches, moved unchanged: the Contact's first link, then the Portal User's parent, then nothing. The only difference is that the implicit fall-through is now an explicit `None`.

## What existing behaviour does this change

Deliberately narrow:

- **Signed-in shopper with a Customer** — nothing changes. Same party, same price list, same pricing rules.
- **Signed-in shopper without a Customer** — the catalogue prices with `Webshop Settings.price_list` instead of the default price list of a Customer created a millisecond earlier, which carries no pricing rules of its own. Same price shown, one fewer record written.
- **Guest** — nothing changes. `get_price` already guards with `if party and party.doctype == "Customer"` (`erpnext/utilities/product.py`), so `None` is a value it already handles.
- **Add to cart, checkout, quotations, sales orders** — nothing changes. Those paths create exactly as they did.

The two address getters return `[]` for a shopper with no party, instead of creating one in order to list its zero addresses.

## Tests

Three added to `test_shopping_cart.py`, one per claim:

- `test_get_party_resolves_without_creating` — a shopper with no party resolves to `None`, and the Customer count does not move.
- `test_browsing_the_catalogue_does_not_create_a_customer` — the regression this PR is about, asserted through `get_product_info_for_website`.
- `test_get_or_create_party_creates_once` — the creating path still creates, and only once.

## Prerequisite

The webshop suite does not run on `develop` today — eight independent breakages, from the CI's Python version to erpnext's new permission checks, none of them related to this change. They are fixed in #372, which this branch is stacked on; without it there is no way to demonstrate anything here.

## Verification

Fresh bench, fresh site, frappe `16.24.3` / erpnext `16.30.0` / payments / webshop:

| | tests | result |
| --- | --- | --- |
| `develop` + the prerequisite fixes | 41 + 3 | OK |
| this branch | **44 + 3** | **OK** |

The three added tests are the entire difference.

I also exercised it against a live storefront carrying ~28,700 Customers:

- a signed-in shopper with no linked party resolves to `None`, and the Customer count does not move
- a shopper who has a Customer resolves to the same one as before
- `get_product_info_for_website` as **Guest** neither raises nor creates
- a signed-in shopper with a Customer still gets the full price with pricing rules applied
