### PR TITLE
chore: add dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,11 @@ dependencies = []
 requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"
 
+[tool.bench.frappe-dependencies]
+frappe = ">=16.0.0,<17.0.0"
+erpnext = ">=16.0.0,<17.0.0"
+payments = ">=16.0.0,<17.0.0"
+
 [tool.black]
 line-length = 99
 


### PR DESCRIPTION
Add the missing Bench dependency required by Frappe Cloud.